### PR TITLE
feat: add briefs/artifacts table with MCP tools, search, and dedupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Named after the Library of Alexandria — a single repository holding all knowle
 
 ## Features
 
-- **25 MCP tools** for memories, projects, health, training, and knowledge graph
+- **28 MCP tools** for memories, briefs, projects, health, training, and knowledge graph
 - **Semantic search** with pgvector (HNSW indexes)
 - **Auto-classification and embedding** via OpenRouter (GPT-4o-mini + text-embedding-3-small)
 - **Knowledge graph** with entity extraction from memories
@@ -45,11 +45,12 @@ Supabase Edge Function (Deno + Hono + MCP SDK)
 
 `schema/schema.sql` is the canonical schema for fresh installs, and it must stay identical to the consolidated bootstrap migration in `supabase/migrations/*_alexandria_schema.sql`.
 
-9 tables in a single consolidated [`schema/schema.sql`](schema/schema.sql):
+10 tables in a single consolidated [`schema/schema.sql`](schema/schema.sql):
 
 | Table | Description |
 |-------|-------------|
 | `memories` | Notes, ideas, decisions, observations |
+| `briefs` | Structured markdown artifacts from cron/jobs with dedupe + semantic recall |
 | `projects` | Codebase context, architecture, conventions |
 | `profile` | User preferences, dev stack, environment |
 | `health_entries` | Health data (sleep, exercise, vitals, body composition) |
@@ -66,6 +67,11 @@ Supabase Edge Function (Deno + Hono + MCP SDK)
 - `capture_memory` — save a new memory (auto-embeds + classifies)
 - `list_memories` — list/filter recent memories
 - `memory_stats` — summary statistics
+
+### Briefs
+- `capture_brief` — store a structured brief/report artifact
+- `list_briefs` — list/filter recent briefs
+- `search_briefs` — semantic search across stored briefs
 
 ### Profile
 - `get_profile` — retrieve profile sections

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -56,6 +56,25 @@ CREATE TABLE projects (
     updated_at  TIMESTAMPTZ DEFAULT now() NOT NULL
 );
 
+-- Briefs: structured report artifacts from cron/jobs for recall + dedupe
+CREATE TABLE briefs (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID REFERENCES auth.users(id),
+    source_job    TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    brief_date    DATE NOT NULL,
+    kind          TEXT NOT NULL,
+    body_markdown TEXT NOT NULL,
+    topics        TEXT[] DEFAULT '{}',
+    project_refs  TEXT[] DEFAULT '{}',
+    entity_refs   TEXT[] DEFAULT '{}',
+    content_hash  TEXT NOT NULL UNIQUE,
+    embedding     vector(1536),
+    metadata      JSONB DEFAULT '{}',
+    created_at    TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at    TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
 -- Profile: who you are, preferences, conventions
 CREATE TABLE profile (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -198,6 +217,18 @@ CREATE INDEX idx_projects_name ON projects (name);
 CREATE INDEX idx_projects_status ON projects (status);
 CREATE INDEX idx_projects_user_id ON projects(user_id);
 
+-- Briefs
+CREATE INDEX idx_briefs_date ON briefs (brief_date DESC);
+CREATE INDEX idx_briefs_kind ON briefs (kind);
+CREATE INDEX idx_briefs_source_job ON briefs (source_job);
+CREATE INDEX idx_briefs_topics ON briefs USING gin (topics);
+CREATE INDEX idx_briefs_project_refs ON briefs USING gin (project_refs);
+CREATE INDEX idx_briefs_entity_refs ON briefs USING gin (entity_refs);
+CREATE INDEX idx_briefs_metadata ON briefs USING gin (metadata);
+CREATE INDEX idx_briefs_user_id ON briefs(user_id);
+CREATE INDEX idx_briefs_embedding ON briefs
+    USING hnsw (embedding vector_cosine_ops);
+
 -- Profile
 CREATE UNIQUE INDEX profile_key_owner_unique ON profile (key, owner_id)
     WHERE owner_id IS NOT NULL;
@@ -273,6 +304,54 @@ BEGIN
       AND (filter_category IS NULL OR m.category = filter_category)
       AND (filter_tags IS NULL OR m.tags @> filter_tags)
     ORDER BY m.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+-- Search briefs by vector similarity
+CREATE OR REPLACE FUNCTION search_briefs(
+    query_embedding vector(1536),
+    match_threshold FLOAT DEFAULT 0.4,
+    match_count INT DEFAULT 10,
+    filter_kind TEXT DEFAULT NULL,
+    filter_source_job TEXT DEFAULT NULL,
+    filter_date_from DATE DEFAULT NULL,
+    filter_date_to DATE DEFAULT NULL,
+    filter_topics TEXT[] DEFAULT NULL,
+    filter_project_refs TEXT[] DEFAULT NULL,
+    filter_entity_refs TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    source_job TEXT,
+    title TEXT,
+    brief_date DATE,
+    kind TEXT,
+    body_markdown TEXT,
+    topics TEXT[],
+    project_refs TEXT[],
+    entity_refs TEXT[],
+    metadata JSONB,
+    similarity FLOAT,
+    created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT b.id, b.source_job, b.title, b.brief_date, b.kind, b.body_markdown,
+        b.topics, b.project_refs, b.entity_refs, b.metadata,
+        1 - (b.embedding <=> query_embedding) AS similarity,
+        b.created_at
+    FROM briefs b
+    WHERE (1 - (b.embedding <=> query_embedding)) > match_threshold
+      AND (filter_kind IS NULL OR b.kind = filter_kind)
+      AND (filter_source_job IS NULL OR b.source_job = filter_source_job)
+      AND (filter_date_from IS NULL OR b.brief_date >= filter_date_from)
+      AND (filter_date_to IS NULL OR b.brief_date <= filter_date_to)
+      AND (filter_topics IS NULL OR b.topics @> filter_topics)
+      AND (filter_project_refs IS NULL OR b.project_refs @> filter_project_refs)
+      AND (filter_entity_refs IS NULL OR b.entity_refs @> filter_entity_refs)
+    ORDER BY b.embedding <=> query_embedding
     LIMIT match_count;
 END;
 $$;
@@ -529,6 +608,8 @@ CREATE TRIGGER memories_updated_at
     BEFORE UPDATE ON memories FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER projects_updated_at
     BEFORE UPDATE ON projects FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+CREATE TRIGGER briefs_updated_at
+    BEFORE UPDATE ON briefs FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER training_logs_updated_at
     BEFORE UPDATE ON training_logs FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER entities_updated_at
@@ -539,6 +620,7 @@ CREATE TRIGGER entities_updated_at
 -- ============================================================
 ALTER TABLE memories ENABLE ROW LEVEL SECURITY;
 ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE briefs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE profile ENABLE ROW LEVEL SECURITY;
 ALTER TABLE health_entries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE training_logs ENABLE ROW LEVEL SECURITY;
@@ -555,6 +637,8 @@ ALTER TABLE sync_log ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "service_role_full_access" ON memories
     FOR ALL USING (auth.role() = 'service_role');
 CREATE POLICY "service_role_full_access" ON projects
+    FOR ALL USING (auth.role() = 'service_role');
+CREATE POLICY "service_role_full_access" ON briefs
     FOR ALL USING (auth.role() = 'service_role');
 CREATE POLICY "service_role_full_access" ON profile
     FOR ALL USING (auth.role() = 'service_role');
@@ -676,11 +760,35 @@ CREATE POLICY "users_update_own_projects" ON projects
         OR auth.role() = 'service_role'
     );
 
+-- Authenticated users: briefs
+CREATE POLICY "users_read_own_briefs" ON briefs
+    FOR SELECT USING (
+        auth.uid() = user_id
+        OR user_id IS NULL
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_insert_own_briefs" ON briefs
+    FOR INSERT WITH CHECK (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_update_own_briefs" ON briefs
+    FOR UPDATE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_delete_own_briefs" ON briefs
+    FOR DELETE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+
 -- ============================================================
 -- GRANTS
 -- ============================================================
 GRANT SELECT, INSERT, UPDATE, DELETE ON memories TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON profile TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON health_entries TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON training_logs TO service_role;
@@ -691,6 +799,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON sync_log TO service_role;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON memories TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON profile TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON health_entries TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON training_logs TO authenticated;

--- a/supabase/functions/alexandria/index.ts
+++ b/supabase/functions/alexandria/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./config.ts";
 
 import { registerMemoriesTools } from "./tools/memories.ts";
+import { registerBriefsTools } from "./tools/briefs.ts";
 import { registerProfileTools } from "./tools/profile.ts";
 import { registerProjectsTools } from "./tools/projects.ts";
 import { registerHealthTools } from "./tools/health.ts";
@@ -31,6 +32,7 @@ let currentAuth: AuthContext | undefined;
 const getAuth = () => currentAuth;
 
 registerMemoriesTools(server, getAuth);
+registerBriefsTools(server, getAuth);
 registerProfileTools(server, getAuth);
 registerProjectsTools(server, getAuth);
 registerHealthTools(server, getAuth);

--- a/supabase/functions/alexandria/lib.test.ts
+++ b/supabase/functions/alexandria/lib.test.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore no-import-prefix
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.12";
 import {
+  briefToText,
+  computeBriefContentHash,
   extractNumericValue,
+  normalizeBriefBody,
+  normalizeStringArray,
   recordToText,
   sanitizeClassification,
   simpleClassify,
@@ -404,4 +408,80 @@ Deno.test("recordToText uses timestamp fallback correctly", () => {
   assertExists(result);
   assertEquals(result.includes("10,000"), true);
   assertEquals(result.includes("steps"), true);
+});
+
+// --- brief helpers ---
+
+Deno.test("normalizeStringArray trims, dedupes, and lowercases when requested", () => {
+  assertEquals(
+    normalizeStringArray([" ETF Flows ", "etf flows", "Hyperliquid", ""], {
+      lowercase: true,
+    }),
+    ["etf flows", "hyperliquid"],
+  );
+});
+
+Deno.test("normalizeBriefBody normalizes line endings and trims edges", () => {
+  assertEquals(
+    normalizeBriefBody("\nLine 1\r\nLine 2\r\n\n"),
+    "Line 1\nLine 2",
+  );
+});
+
+Deno.test("computeBriefContentHash is stable across line-ending differences", async () => {
+  const a = await computeBriefContentHash({
+    source_job: "research-pack",
+    title: "Morning Brief",
+    brief_date: "2026-06-06",
+    kind: "night_research",
+    body_markdown: "## Summary\nLine 1\nLine 2\n",
+  });
+  const b = await computeBriefContentHash({
+    source_job: "research-pack",
+    title: "Morning Brief",
+    brief_date: "2026-06-06",
+    kind: "night_research",
+    body_markdown: "\r\n## Summary\r\nLine 1\r\nLine 2\r\n",
+  });
+
+  assertEquals(a, b);
+});
+
+Deno.test("computeBriefContentHash changes when brief identity changes", async () => {
+  const a = await computeBriefContentHash({
+    source_job: "research-pack",
+    title: "Morning Brief",
+    brief_date: "2026-06-06",
+    kind: "night_research",
+    body_markdown: "same body",
+  });
+  const b = await computeBriefContentHash({
+    source_job: "research-pack",
+    title: "Morning Brief",
+    brief_date: "2026-06-07",
+    kind: "night_research",
+    body_markdown: "same body",
+  });
+
+  assertEquals(a === b, false);
+});
+
+Deno.test("briefToText includes metadata and markdown body for semantic indexing", () => {
+  const result = briefToText({
+    title: "ETF + Hyperliquid",
+    brief_date: "2026-06-06",
+    kind: "content_coach",
+    source_job: "content-coach",
+    topics: ["ETF flows", "Hyperliquid"],
+    project_refs: ["wyde"],
+    entity_refs: ["Intmax"],
+    body_markdown: "## Talking Points\n- ETF flows still dominate",
+  });
+
+  assertEquals(result.includes("ETF + Hyperliquid"), true);
+  assertEquals(result.includes("content-coach"), true);
+  assertEquals(result.includes("topics: etf flows, hyperliquid"), true);
+  assertEquals(result.includes("projects: wyde"), true);
+  assertEquals(result.includes("entities: Intmax"), true);
+  assertEquals(result.includes("## Talking Points"), true);
 });

--- a/supabase/functions/alexandria/lib.ts
+++ b/supabase/functions/alexandria/lib.ts
@@ -22,6 +22,48 @@ export const VALID_SOURCES = [
   "auto",
 ] as const;
 
+export function normalizeStringArray(
+  values: unknown,
+  opts: { lowercase?: boolean; maxItems?: number } = {},
+): string[] {
+  const { lowercase = false, maxItems = 25 } = opts;
+  if (!Array.isArray(values)) return [];
+
+  const normalized = values
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+    .map((value) => lowercase ? value.toLowerCase() : value);
+
+  return [...new Set(normalized)].slice(0, maxItems);
+}
+
+export function normalizeBriefBody(body: string): string {
+  return body.replace(/\r\n/g, "\n").trim();
+}
+
+export async function computeBriefContentHash(input: {
+  source_job: string;
+  title: string;
+  brief_date: string;
+  kind: string;
+  body_markdown: string;
+}): Promise<string> {
+  const canonical = JSON.stringify({
+    source_job: input.source_job.trim(),
+    title: input.title.trim(),
+    brief_date: input.brief_date.trim(),
+    kind: input.kind.trim().toLowerCase(),
+    body_markdown: normalizeBriefBody(input.body_markdown),
+  });
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 export function sanitizeClassification(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -194,6 +236,26 @@ export function workoutToText(record: Record<string, unknown>): string {
   }
 
   return parts.join(": ") + (exercises?.length ? "" : "");
+}
+
+export function briefToText(record: Record<string, unknown>): string {
+  const title = (record.title as string) || "Untitled brief";
+  const briefDate = (record.brief_date as string) || "unknown date";
+  const kind = (record.kind as string) || "brief";
+  const sourceJob = (record.source_job as string) || "unknown-source";
+  const body = normalizeBriefBody((record.body_markdown as string) || "");
+  const topics = normalizeStringArray(record.topics, { lowercase: true });
+  const projectRefs = normalizeStringArray(record.project_refs);
+  const entityRefs = normalizeStringArray(record.entity_refs);
+
+  const parts = [
+    `Brief '${title}' (${kind}) from ${sourceJob} on ${briefDate}`,
+  ];
+  if (topics.length) parts.push(`topics: ${topics.join(", ")}`);
+  if (projectRefs.length) parts.push(`projects: ${projectRefs.join(", ")}`);
+  if (entityRefs.length) parts.push(`entities: ${entityRefs.join(", ")}`);
+  if (body) parts.push(body);
+  return parts.join("\n");
 }
 
 export function extractNumericValue(

--- a/supabase/functions/alexandria/tools/briefs.ts
+++ b/supabase/functions/alexandria/tools/briefs.ts
@@ -1,0 +1,212 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { supabase, AuthContext } from "../config.ts";
+import { getEmbedding, wrapHandler } from "../helpers.ts";
+import type { BriefRow } from "../types.ts";
+import {
+  briefToText,
+  computeBriefContentHash,
+  normalizeBriefBody,
+  normalizeStringArray,
+} from "../lib.ts";
+
+export function registerBriefsTools(
+  server: McpServer,
+  _getAuth: () => AuthContext | undefined,
+) {
+  server.registerTool(
+    "capture_brief",
+    {
+      title: "Capture Brief",
+      description:
+        "Store a structured markdown brief/report artifact with dedupe and semantic indexing. Use for cron outputs like research packs, content coach notes, synapse diffs, and client watches.",
+      inputSchema: {
+        source_job: z.string().describe("Source cron/job name or producer"),
+        title: z.string().describe("Human-readable brief title"),
+        brief_date: z.string().describe("Date YYYY-MM-DD for the brief"),
+        kind: z.string().describe(
+          "Brief type, e.g. night_research, content_coach, synapse_diff, client_watch",
+        ),
+        body_markdown: z.string().describe("Full markdown body of the brief"),
+        topics: z.array(z.string()).optional().describe("High-level topical tags"),
+        project_refs: z.array(z.string()).optional().describe(
+          "Project names or slugs referenced by the brief",
+        ),
+        entity_refs: z.array(z.string()).optional().describe(
+          "Entity names referenced by the brief",
+        ),
+        metadata: z.record(z.any()).optional().describe("Optional structured metadata"),
+      },
+    },
+    wrapHandler(
+      async ({
+        source_job,
+        title,
+        brief_date,
+        kind,
+        body_markdown,
+        topics,
+        project_refs,
+        entity_refs,
+        metadata,
+      }) => {
+        const normalizedBody = normalizeBriefBody(body_markdown);
+        const normalizedTopics = normalizeStringArray(topics, { lowercase: true });
+        const normalizedProjectRefs = normalizeStringArray(project_refs);
+        const normalizedEntityRefs = normalizeStringArray(entity_refs);
+        const contentHash = await computeBriefContentHash({
+          source_job,
+          title,
+          brief_date,
+          kind,
+          body_markdown: normalizedBody,
+        });
+
+        const { data: existing, error: existingError } = await supabase
+          .from("briefs")
+          .select("id, title, brief_date, kind, source_job")
+          .eq("content_hash", contentHash)
+          .maybeSingle();
+        if (existingError) throw new Error("Brief lookup failed");
+
+        if (existing) {
+          return `Duplicate brief blocked: \"${existing.title}\" (${existing.kind}) from ${existing.source_job} on ${existing.brief_date}.`;
+        }
+
+        const row: Record<string, unknown> = {
+          source_job: source_job.trim(),
+          title: title.trim(),
+          brief_date,
+          kind: kind.trim().toLowerCase(),
+          body_markdown: normalizedBody,
+          topics: normalizedTopics,
+          project_refs: normalizedProjectRefs,
+          entity_refs: normalizedEntityRefs,
+          content_hash: contentHash,
+          metadata: metadata || {},
+        };
+
+        const embedding = await getEmbedding(briefToText(row));
+        row.embedding = embedding;
+
+        const { data, error } = await supabase
+          .from("briefs")
+          .insert(row)
+          .select("id")
+          .single();
+
+        if (error || !data) throw new Error("Brief capture failed");
+
+        return `Captured brief: \"${title.trim()}\" (${kind.trim().toLowerCase()}) for ${brief_date} from ${source_job.trim()} [${data.id}]`;
+      },
+    ),
+  );
+
+  server.registerTool(
+    "list_briefs",
+    {
+      title: "List Briefs",
+      description:
+        "List structured briefs with optional filters by date, source job, kind, topic, project ref, or entity ref.",
+      inputSchema: {
+        limit: z.number().optional().default(10),
+        kind: z.string().optional().describe("Filter by brief kind"),
+        source_job: z.string().optional().describe("Filter by source job/producer"),
+        from: z.string().optional().describe("Start date YYYY-MM-DD"),
+        to: z.string().optional().describe("End date YYYY-MM-DD"),
+        topic: z.string().optional().describe("Filter by topic tag"),
+        project_ref: z.string().optional().describe("Filter by project reference"),
+        entity_ref: z.string().optional().describe("Filter by entity reference"),
+      },
+    },
+    wrapHandler(async ({ limit, kind, source_job, from, to, topic, project_ref, entity_ref }) => {
+      let q = supabase
+        .from("briefs")
+        .select(
+          "id, source_job, title, brief_date, kind, topics, project_refs, entity_refs, created_at",
+        )
+        .order("brief_date", { ascending: false })
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (kind) q = q.eq("kind", kind.trim().toLowerCase());
+      if (source_job) q = q.eq("source_job", source_job.trim());
+      if (from) q = q.gte("brief_date", from);
+      if (to) q = q.lte("brief_date", to);
+      if (topic) q = q.contains("topics", [topic.trim().toLowerCase()]);
+      if (project_ref) q = q.contains("project_refs", [project_ref.trim()]);
+      if (entity_ref) q = q.contains("entity_refs", [entity_ref.trim()]);
+
+      const { data, error } = await q;
+      if (error) throw new Error(error.message);
+      if (!data?.length) return "No briefs found.";
+
+      const results = (data as BriefRow[]).map((brief, index) => {
+        const meta: string[] = [
+          `${index + 1}. [${brief.brief_date}] ${brief.title} (${brief.kind})`,
+          `   Source: ${brief.source_job}`,
+        ];
+        if (brief.topics?.length) meta.push(`   Topics: ${brief.topics.join(", ")}`);
+        if (brief.project_refs?.length) meta.push(`   Projects: ${brief.project_refs.join(", ")}`);
+        if (brief.entity_refs?.length) meta.push(`   Entities: ${brief.entity_refs.join(", ")}`);
+        return meta.join("\n");
+      });
+
+      return `${data.length} brief(s):\n\n${results.join("\n\n")}`;
+    }),
+  );
+
+  server.registerTool(
+    "search_briefs",
+    {
+      title: "Search Briefs",
+      description:
+        "Semantic search across stored briefs. Use to recall what the system already proposed today, recent client intel, or past research angles.",
+      inputSchema: {
+        query: z.string().describe("Natural language search query"),
+        limit: z.number().optional().default(10),
+        threshold: z.number().optional().default(0.4),
+        kind: z.string().optional().describe("Filter by brief kind"),
+        source_job: z.string().optional().describe("Filter by source job/producer"),
+        from: z.string().optional().describe("Start date YYYY-MM-DD"),
+        to: z.string().optional().describe("End date YYYY-MM-DD"),
+        topic: z.string().optional().describe("Filter by topic tag"),
+        project_ref: z.string().optional().describe("Filter by project reference"),
+        entity_ref: z.string().optional().describe("Filter by entity reference"),
+      },
+    },
+    wrapHandler(async ({ query, limit, threshold, kind, source_job, from, to, topic, project_ref, entity_ref }) => {
+      const qEmb = await getEmbedding(query);
+      const { data, error } = await supabase.rpc("search_briefs", {
+        query_embedding: qEmb,
+        match_threshold: threshold,
+        match_count: limit,
+        filter_kind: kind ? kind.trim().toLowerCase() : null,
+        filter_source_job: source_job ? source_job.trim() : null,
+        filter_date_from: from || null,
+        filter_date_to: to || null,
+        filter_topics: topic ? [topic.trim().toLowerCase()] : null,
+        filter_project_refs: project_ref ? [project_ref.trim()] : null,
+        filter_entity_refs: entity_ref ? [entity_ref.trim()] : null,
+      });
+
+      if (error) throw new Error("Brief search failed");
+      if (!data?.length) return `No briefs found matching \"${query}\".`;
+
+      const results = data.map((brief: any, index: number) => {
+        const parts = [
+          `--- ${index + 1}. ${(brief.similarity * 100).toFixed(1)}% match ---`,
+          `Title: ${brief.title}`,
+          `Kind: ${brief.kind} | Source: ${brief.source_job} | Date: ${brief.brief_date}`,
+        ];
+        if (brief.topics?.length) parts.push(`Topics: ${brief.topics.join(", ")}`);
+        if (brief.project_refs?.length) parts.push(`Projects: ${brief.project_refs.join(", ")}`);
+        if (brief.entity_refs?.length) parts.push(`Entities: ${brief.entity_refs.join(", ")}`);
+        parts.push(`\n${brief.body_markdown}`);
+        return parts.join("\n");
+      });
+
+      return `Found ${data.length} brief(s):\n\n${results.join("\n\n")}`;
+    }),
+  );
+}

--- a/supabase/functions/alexandria/types.ts
+++ b/supabase/functions/alexandria/types.ts
@@ -25,6 +25,24 @@ export interface ProjectRow {
   updated_at: string;
 }
 
+export interface BriefRow {
+  id: string;
+  user_id: string | null;
+  source_job: string;
+  title: string;
+  brief_date: string;
+  kind: string;
+  body_markdown: string;
+  topics: string[] | null;
+  project_refs: string[] | null;
+  entity_refs: string[] | null;
+  content_hash: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  embedding: number[] | null;
+}
+
 export interface HealthEntryRow {
   id: string;
   user_id: string;

--- a/supabase/migrations/20260429160331_alexandria_schema.sql
+++ b/supabase/migrations/20260429160331_alexandria_schema.sql
@@ -56,6 +56,25 @@ CREATE TABLE projects (
     updated_at  TIMESTAMPTZ DEFAULT now() NOT NULL
 );
 
+-- Briefs: structured report artifacts from cron/jobs for recall + dedupe
+CREATE TABLE briefs (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID REFERENCES auth.users(id),
+    source_job    TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    brief_date    DATE NOT NULL,
+    kind          TEXT NOT NULL,
+    body_markdown TEXT NOT NULL,
+    topics        TEXT[] DEFAULT '{}',
+    project_refs  TEXT[] DEFAULT '{}',
+    entity_refs   TEXT[] DEFAULT '{}',
+    content_hash  TEXT NOT NULL UNIQUE,
+    embedding     vector(1536),
+    metadata      JSONB DEFAULT '{}',
+    created_at    TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at    TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
 -- Profile: who you are, preferences, conventions
 CREATE TABLE profile (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -198,6 +217,18 @@ CREATE INDEX idx_projects_name ON projects (name);
 CREATE INDEX idx_projects_status ON projects (status);
 CREATE INDEX idx_projects_user_id ON projects(user_id);
 
+-- Briefs
+CREATE INDEX idx_briefs_date ON briefs (brief_date DESC);
+CREATE INDEX idx_briefs_kind ON briefs (kind);
+CREATE INDEX idx_briefs_source_job ON briefs (source_job);
+CREATE INDEX idx_briefs_topics ON briefs USING gin (topics);
+CREATE INDEX idx_briefs_project_refs ON briefs USING gin (project_refs);
+CREATE INDEX idx_briefs_entity_refs ON briefs USING gin (entity_refs);
+CREATE INDEX idx_briefs_metadata ON briefs USING gin (metadata);
+CREATE INDEX idx_briefs_user_id ON briefs(user_id);
+CREATE INDEX idx_briefs_embedding ON briefs
+    USING hnsw (embedding vector_cosine_ops);
+
 -- Profile
 CREATE UNIQUE INDEX profile_key_owner_unique ON profile (key, owner_id)
     WHERE owner_id IS NOT NULL;
@@ -273,6 +304,54 @@ BEGIN
       AND (filter_category IS NULL OR m.category = filter_category)
       AND (filter_tags IS NULL OR m.tags @> filter_tags)
     ORDER BY m.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+-- Search briefs by vector similarity
+CREATE OR REPLACE FUNCTION search_briefs(
+    query_embedding vector(1536),
+    match_threshold FLOAT DEFAULT 0.4,
+    match_count INT DEFAULT 10,
+    filter_kind TEXT DEFAULT NULL,
+    filter_source_job TEXT DEFAULT NULL,
+    filter_date_from DATE DEFAULT NULL,
+    filter_date_to DATE DEFAULT NULL,
+    filter_topics TEXT[] DEFAULT NULL,
+    filter_project_refs TEXT[] DEFAULT NULL,
+    filter_entity_refs TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    source_job TEXT,
+    title TEXT,
+    brief_date DATE,
+    kind TEXT,
+    body_markdown TEXT,
+    topics TEXT[],
+    project_refs TEXT[],
+    entity_refs TEXT[],
+    metadata JSONB,
+    similarity FLOAT,
+    created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT b.id, b.source_job, b.title, b.brief_date, b.kind, b.body_markdown,
+        b.topics, b.project_refs, b.entity_refs, b.metadata,
+        1 - (b.embedding <=> query_embedding) AS similarity,
+        b.created_at
+    FROM briefs b
+    WHERE (1 - (b.embedding <=> query_embedding)) > match_threshold
+      AND (filter_kind IS NULL OR b.kind = filter_kind)
+      AND (filter_source_job IS NULL OR b.source_job = filter_source_job)
+      AND (filter_date_from IS NULL OR b.brief_date >= filter_date_from)
+      AND (filter_date_to IS NULL OR b.brief_date <= filter_date_to)
+      AND (filter_topics IS NULL OR b.topics @> filter_topics)
+      AND (filter_project_refs IS NULL OR b.project_refs @> filter_project_refs)
+      AND (filter_entity_refs IS NULL OR b.entity_refs @> filter_entity_refs)
+    ORDER BY b.embedding <=> query_embedding
     LIMIT match_count;
 END;
 $$;
@@ -529,6 +608,8 @@ CREATE TRIGGER memories_updated_at
     BEFORE UPDATE ON memories FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER projects_updated_at
     BEFORE UPDATE ON projects FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+CREATE TRIGGER briefs_updated_at
+    BEFORE UPDATE ON briefs FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER training_logs_updated_at
     BEFORE UPDATE ON training_logs FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER entities_updated_at
@@ -539,6 +620,7 @@ CREATE TRIGGER entities_updated_at
 -- ============================================================
 ALTER TABLE memories ENABLE ROW LEVEL SECURITY;
 ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE briefs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE profile ENABLE ROW LEVEL SECURITY;
 ALTER TABLE health_entries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE training_logs ENABLE ROW LEVEL SECURITY;
@@ -555,6 +637,8 @@ ALTER TABLE sync_log ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "service_role_full_access" ON memories
     FOR ALL USING (auth.role() = 'service_role');
 CREATE POLICY "service_role_full_access" ON projects
+    FOR ALL USING (auth.role() = 'service_role');
+CREATE POLICY "service_role_full_access" ON briefs
     FOR ALL USING (auth.role() = 'service_role');
 CREATE POLICY "service_role_full_access" ON profile
     FOR ALL USING (auth.role() = 'service_role');
@@ -676,11 +760,35 @@ CREATE POLICY "users_update_own_projects" ON projects
         OR auth.role() = 'service_role'
     );
 
+-- Authenticated users: briefs
+CREATE POLICY "users_read_own_briefs" ON briefs
+    FOR SELECT USING (
+        auth.uid() = user_id
+        OR user_id IS NULL
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_insert_own_briefs" ON briefs
+    FOR INSERT WITH CHECK (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_update_own_briefs" ON briefs
+    FOR UPDATE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+CREATE POLICY "users_delete_own_briefs" ON briefs
+    FOR DELETE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+
 -- ============================================================
 -- GRANTS
 -- ============================================================
 GRANT SELECT, INSERT, UPDATE, DELETE ON memories TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON profile TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON health_entries TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON training_logs TO service_role;
@@ -691,6 +799,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON sync_log TO service_role;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON memories TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON profile TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON health_entries TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON training_logs TO authenticated;

--- a/supabase/migrations/20260606193000_add_briefs_artifacts.sql
+++ b/supabase/migrations/20260606193000_add_briefs_artifacts.sql
@@ -1,0 +1,114 @@
+CREATE TABLE IF NOT EXISTS briefs (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID REFERENCES auth.users(id),
+    source_job    TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    brief_date    DATE NOT NULL,
+    kind          TEXT NOT NULL,
+    body_markdown TEXT NOT NULL,
+    topics        TEXT[] DEFAULT '{}',
+    project_refs  TEXT[] DEFAULT '{}',
+    entity_refs   TEXT[] DEFAULT '{}',
+    content_hash  TEXT NOT NULL UNIQUE,
+    embedding     vector(1536),
+    metadata      JSONB DEFAULT '{}',
+    created_at    TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at    TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_briefs_date ON briefs (brief_date DESC);
+CREATE INDEX IF NOT EXISTS idx_briefs_kind ON briefs (kind);
+CREATE INDEX IF NOT EXISTS idx_briefs_source_job ON briefs (source_job);
+CREATE INDEX IF NOT EXISTS idx_briefs_topics ON briefs USING gin (topics);
+CREATE INDEX IF NOT EXISTS idx_briefs_project_refs ON briefs USING gin (project_refs);
+CREATE INDEX IF NOT EXISTS idx_briefs_entity_refs ON briefs USING gin (entity_refs);
+CREATE INDEX IF NOT EXISTS idx_briefs_metadata ON briefs USING gin (metadata);
+CREATE INDEX IF NOT EXISTS idx_briefs_user_id ON briefs(user_id);
+CREATE INDEX IF NOT EXISTS idx_briefs_embedding ON briefs
+    USING hnsw (embedding vector_cosine_ops);
+
+CREATE OR REPLACE FUNCTION search_briefs(
+    query_embedding vector(1536),
+    match_threshold FLOAT DEFAULT 0.4,
+    match_count INT DEFAULT 10,
+    filter_kind TEXT DEFAULT NULL,
+    filter_source_job TEXT DEFAULT NULL,
+    filter_date_from DATE DEFAULT NULL,
+    filter_date_to DATE DEFAULT NULL,
+    filter_topics TEXT[] DEFAULT NULL,
+    filter_project_refs TEXT[] DEFAULT NULL,
+    filter_entity_refs TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    source_job TEXT,
+    title TEXT,
+    brief_date DATE,
+    kind TEXT,
+    body_markdown TEXT,
+    topics TEXT[],
+    project_refs TEXT[],
+    entity_refs TEXT[],
+    metadata JSONB,
+    similarity FLOAT,
+    created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT b.id, b.source_job, b.title, b.brief_date, b.kind, b.body_markdown,
+        b.topics, b.project_refs, b.entity_refs, b.metadata,
+        1 - (b.embedding <=> query_embedding) AS similarity,
+        b.created_at
+    FROM briefs b
+    WHERE (1 - (b.embedding <=> query_embedding)) > match_threshold
+      AND (filter_kind IS NULL OR b.kind = filter_kind)
+      AND (filter_source_job IS NULL OR b.source_job = filter_source_job)
+      AND (filter_date_from IS NULL OR b.brief_date >= filter_date_from)
+      AND (filter_date_to IS NULL OR b.brief_date <= filter_date_to)
+      AND (filter_topics IS NULL OR b.topics @> filter_topics)
+      AND (filter_project_refs IS NULL OR b.project_refs @> filter_project_refs)
+      AND (filter_entity_refs IS NULL OR b.entity_refs @> filter_entity_refs)
+    ORDER BY b.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS briefs_updated_at ON briefs;
+CREATE TRIGGER briefs_updated_at
+    BEFORE UPDATE ON briefs FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE briefs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON briefs;
+CREATE POLICY "service_role_full_access" ON briefs
+    FOR ALL USING (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "users_read_own_briefs" ON briefs;
+CREATE POLICY "users_read_own_briefs" ON briefs
+    FOR SELECT USING (
+        auth.uid() = user_id
+        OR user_id IS NULL
+        OR auth.role() = 'service_role'
+    );
+DROP POLICY IF EXISTS "users_insert_own_briefs" ON briefs;
+CREATE POLICY "users_insert_own_briefs" ON briefs
+    FOR INSERT WITH CHECK (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+DROP POLICY IF EXISTS "users_update_own_briefs" ON briefs;
+CREATE POLICY "users_update_own_briefs" ON briefs
+    FOR UPDATE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+DROP POLICY IF EXISTS "users_delete_own_briefs" ON briefs;
+CREATE POLICY "users_delete_own_briefs" ON briefs
+    FOR DELETE USING (
+        auth.uid() = user_id
+        OR auth.role() = 'service_role'
+    );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON briefs TO authenticated;


### PR DESCRIPTION
## Changes

- New `briefs` table: structured markdown artifacts from cron/jobs with `content_hash` dedupe, pgvector embedding, topics/project/entity refs
- 3 MCP tools: `capture_brief` (with dedupe), `list_briefs` (7 filters), `search_briefs` (semantic search with filters)
- `search_briefs()` SQL function with 7 filter dimensions + HNSW index
- Helpers in `lib.ts`: `briefToText`, `computeBriefContentHash`, `normalizeBriefBody` with 5 unit tests
- Incremental migration is fully idempotent (`IF NOT EXISTS` + `DROP IF EXISTS`)
- RLS policies, grants, trigger aligned with existing convention

## Testing
- Schema drift: ✅
- 84 Python tests: ✅
- 53 Deno tests: ✅
- `deno check` with config: ✅
- Independent code review: ✅ (1 blocker found and fixed — migration idempotency)

Closes #10