### PR TITLE
feat: add bodycomp_summary tool with delta tracking and goal progress

### DIFF
--- a/supabase/functions/alexandria/lib.test.ts
+++ b/supabase/functions/alexandria/lib.test.ts
@@ -2,8 +2,11 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.12";
 import {
   briefToText,
+  computeBodyCompDelta,
   computeBriefContentHash,
+  extractBodyCompMetrics,
   extractNumericValue,
+  formatBodyCompSummary,
   normalizeBriefBody,
   normalizeStringArray,
   recordToText,
@@ -13,6 +16,90 @@ import {
   VALID_SOURCES,
   workoutToText,
 } from "./lib.ts";
+
+// --- extractBodyCompMetrics ---
+
+Deno.test("extractBodyCompMetrics extracts all fields when present", () => {
+  const value = {
+    weight_kg: 80,
+    body_fat_percent: 15.5,
+    skeletal_muscle_kg: 35.2,
+    body_water_kg: 45,
+    waist_cm: 85,
+    chest_cm: 100,
+    arm_cm: 32,
+    thigh_cm: 55,
+    calf_cm: 38,
+  };
+  const result = extractBodyCompMetrics(value);
+  assertEquals(result, value);
+});
+
+Deno.test("extractBodyCompMetrics returns null for missing fields", () => {
+  const value = {
+    weight_kg: 80,
+    body_fat_percent: 15.5,
+  };
+  const result = extractBodyCompMetrics(value);
+  assertEquals(result.weight_kg, 80);
+  assertEquals(result.body_fat_percent, 15.5);
+  assertEquals(result.skeletal_muscle_kg, null);
+  assertEquals(result.waist_cm, null);
+});
+
+// --- computeBodyCompDelta ---
+
+Deno.test("computeBodyCompDelta computes positive/negative/zero deltas correctly", () => {
+  const current = { weight_kg: 80.5, body_fat_percent: 15.0, waist_cm: 85 };
+  const previous = { weight_kg: 80.0, body_fat_percent: 15.5, waist_cm: 85 };
+  const result = computeBodyCompDelta(current, previous);
+
+  assertEquals(result.weight_kg, { delta: 0.5, direction: "up" });
+  assertEquals(result.body_fat_percent, { delta: -0.5, direction: "down" });
+  assertEquals(result.waist_cm, { delta: 0, direction: "flat" });
+});
+
+Deno.test("computeBodyCompDelta returns null when either value is missing", () => {
+  const current = { weight_kg: 80.5, body_fat_percent: 15.0 };
+  const previous = { weight_kg: 80.0, skeletal_muscle_kg: 35 };
+  const result = computeBodyCompDelta(current, previous);
+
+  assertEquals(result.weight_kg, { delta: 0.5, direction: "up" });
+  assertEquals(result.body_fat_percent, null);
+  assertEquals(result.skeletal_muscle_kg, null);
+});
+
+// --- formatBodyCompSummary ---
+
+Deno.test("formatBodyCompSummary includes latest metrics, delta arrows, goals, and quality flags", () => {
+  const entries = [{
+    timestamp: "2025-06-01T08:00:00Z",
+    metrics: { weight_kg: 80.5, body_fat_percent: 15.0 },
+    delta: {
+      weight_kg: { delta: 0.5, direction: "up" },
+      body_fat_percent: { delta: -0.2, direction: "down" },
+    },
+    context: "evening",
+    precision: "day",
+  }];
+  const goals = [{
+    metric_name: "weight_kg",
+    target_value: 78,
+    current_value: 80.5,
+    target_date: "2025-07-01",
+    status: "in_progress",
+  }];
+  const dateRange = { from: "2025-05-01", to: "2025-06-01" };
+
+  const result = formatBodyCompSummary(entries, goals, dateRange);
+
+  assertExists(result);
+  assertEquals(result.includes("Body Composition Check-in Summary"), true);
+  assertEquals(result.includes("Weight: 80.5kg (↑ 0.5kg)"), true);
+  assertEquals(result.includes("Body Fat: 15% (↓ 0.2%)"), true);
+  assertEquals(result.includes("⚠ Non-standard conditions: evening"), true);
+  assertEquals(result.includes("weight_kg: 80.5 → 78 by 2025-07-01 [in_progress]"), true);
+});
 
 // --- simpleClassify ---
 

--- a/supabase/functions/alexandria/lib.ts
+++ b/supabase/functions/alexandria/lib.ts
@@ -287,3 +287,139 @@ export function extractNumericValue(
       return null;
   }
 }
+
+export function extractBodyCompMetrics(
+  value: Record<string, unknown>,
+): Record<string, number | null> {
+  const keys = [
+    "weight_kg",
+    "body_fat_percent",
+    "skeletal_muscle_kg",
+    "body_water_kg",
+    "waist_cm",
+    "chest_cm",
+    "arm_cm",
+    "thigh_cm",
+    "calf_cm",
+  ];
+  const metrics: Record<string, number | null> = {};
+  for (const key of keys) {
+    const val = value[key];
+    metrics[key] = typeof val === "number" ? val : null;
+  }
+  return metrics;
+}
+
+export function computeBodyCompDelta(
+  current: Record<string, number | null>,
+  previous: Record<string, number | null>,
+): Record<string, { delta: number; direction: "up" | "down" | "flat" } | null> {
+  const keys = new Set([...Object.keys(current), ...Object.keys(previous)]);
+  const deltas: Record<
+    string,
+    { delta: number; direction: "up" | "down" | "flat" } | null
+  > = {};
+  for (const key of keys) {
+    const currVal = current[key];
+    const prevVal = previous[key];
+
+    if (currVal != null && prevVal != null) {
+      const delta = currVal - prevVal;
+      const direction = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+      deltas[key] = { delta: parseFloat(delta.toFixed(2)), direction };
+    } else {
+      deltas[key] = null;
+    }
+  }
+  return deltas;
+}
+
+export function formatBodyCompSummary(
+  entries: Array<{
+    timestamp: string;
+    metrics: Record<string, number | null>;
+    delta?: Record<string, any>;
+    context?: string;
+    precision?: string;
+  }>,
+  goals: Array<{
+    metric_name: string;
+    target_value: number;
+    current_value: number | null;
+    target_date: string | null;
+    status: string | null;
+  }>,
+  dateRange: { from: string; to: string },
+): string {
+  if (entries.length === 0) {
+    return "No body composition entries found in the selected period.";
+  }
+
+  const latest = entries[0];
+  const parts = [
+    "Body Composition Check-in Summary",
+    `Period: ${dateRange.from} to ${dateRange.to}`,
+    "",
+    `Latest Snapshot: ${new Date(latest.timestamp).toLocaleDateString()}`,
+  ];
+
+  if (
+    (latest.context && latest.context !== "morning_fast") ||
+    (latest.precision && latest.precision !== "day")
+  ) {
+    parts.push(
+      `⚠ Non-standard conditions: ${latest.context || "unknown context"}, ${
+        latest.precision || "unknown precision"
+      }`,
+    );
+  }
+
+  const metricLabels: Record<string, string> = {
+    weight_kg: "Weight",
+    body_fat_percent: "Body Fat",
+    skeletal_muscle_kg: "Muscle Mass",
+    body_water_kg: "Water",
+    waist_cm: "Waist",
+    chest_cm: "Chest",
+    arm_cm: "Arm",
+    thigh_cm: "Thigh",
+    calf_cm: "Calf",
+  };
+
+  const metricUnits: Record<string, string> = {
+    weight_kg: "kg",
+    body_fat_percent: "%",
+    skeletal_muscle_kg: "kg",
+    body_water_kg: "kg",
+    waist_cm: "cm",
+    chest_cm: "cm",
+    arm_cm: "cm",
+    thigh_cm: "cm",
+    calf_cm: "cm",
+  };
+
+  for (const [key, val] of Object.entries(latest.metrics)) {
+    if (val != null) {
+      let line = `- ${metricLabels[key] || key}: ${val}${metricUnits[key] || ""}`;
+      const d = latest.delta?.[key];
+      if (d) {
+        const arrow = d.direction === "up" ? "↑" : d.direction === "down" ? "↓" : "→";
+        line += ` (${arrow} ${Math.abs(d.delta)}${metricUnits[key] || ""})`;
+      }
+      parts.push(line);
+    }
+  }
+
+  if (goals.length > 0) {
+    parts.push("", "Goal Progress:");
+    for (const g of goals) {
+      const current = g.current_value != null ? `${g.current_value}` : "N/A";
+      const target = g.target_value;
+      const status = g.status ? ` [${g.status}]` : "";
+      const date = g.target_date ? ` by ${g.target_date}` : "";
+      parts.push(`- ${g.metric_name}: ${current} → ${target}${date}${status}`);
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/supabase/functions/alexandria/tools/health.ts
+++ b/supabase/functions/alexandria/tools/health.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import { supabase, AuthContext } from "../config.ts";
 import { getEmbedding, wrapHandler } from "../helpers.ts";
 import {   } from "../types.ts";
-import { recordToText } from "../lib.ts";
+import {
+  computeBodyCompDelta,
+  extractBodyCompMetrics,
+  formatBodyCompSummary,
+  recordToText,
+} from "../lib.ts";
 
 export function registerHealthTools(
   server: McpServer,
@@ -343,6 +348,99 @@ export function registerHealthTools(
       return `Deleted health entry: ${data.entry_type} at ${
         new Date(data.timestamp).toLocaleString()
       }`;
+    }),
+  );
+
+  server.registerTool(
+    "bodycomp_summary",
+    {
+      title: "Body Composition Summary",
+      description:
+        "View body composition trends, deltas, and goal progress. Includes weight, body fat, muscle mass, and body measurements.",
+      inputSchema: {
+        days: z.number().optional().default(30).describe(
+          "How many days back to look",
+        ),
+        from: z.string().optional().describe("ISO date YYYY-MM-DD"),
+        to: z.string().optional().describe("ISO date YYYY-MM-DD"),
+      },
+    },
+    wrapHandler(async ({ days, from, to }) => {
+      const toDate = to ? new Date(to) : new Date();
+      if (to && !to.includes("T")) toDate.setHours(23, 59, 59, 999);
+
+      const fromDate = from ? new Date(from) : new Date(toDate);
+      if (!from) {
+        fromDate.setDate(fromDate.getDate() - (days || 30));
+      }
+      if (from && !from.includes("T")) fromDate.setHours(0, 0, 0, 0);
+
+      const fromISO = fromDate.toISOString();
+      const toISO = toDate.toISOString();
+
+      const { data: entriesData, error: entriesError } = await supabase
+        .from("health_entries")
+        .select("timestamp, value, metadata")
+        .eq("entry_type", "body_composition")
+        .gte("timestamp", fromISO)
+        .lte("timestamp", toISO)
+        .order("timestamp", { ascending: false });
+
+      if (entriesError) throw new Error(entriesError.message);
+
+      const { data: goalsData, error: goalsError } = await supabase
+        .from("health_entries")
+        .select("value")
+        .eq("entry_type", "measurement_goal")
+        .gte("timestamp", fromISO)
+        .lte("timestamp", toISO);
+
+      if (goalsError) throw new Error(goalsError.message);
+
+      if (!entriesData || entriesData.length === 0) {
+        return "No body composition entries found in the selected period.";
+      }
+
+      const processedEntries = entriesData.map((e, i) => {
+        const metrics = extractBodyCompMetrics(
+          e.value as Record<string, unknown>,
+        );
+        const prev = entriesData[i + 1];
+        let delta;
+        if (prev) {
+          const prevMetrics = extractBodyCompMetrics(
+            prev.value as Record<string, unknown>,
+          );
+          delta = computeBodyCompDelta(metrics, prevMetrics);
+        }
+        return {
+          timestamp: e.timestamp,
+          metrics,
+          delta,
+          context: (e.metadata as any)?.measurement_context,
+          precision: (e.metadata as any)?.date_precision,
+        };
+      });
+
+      const processedGoals = (goalsData || []).map((g) => {
+        const v = g.value as any;
+        return {
+          metric_name: v.metric_name,
+          target_value: v.target_value,
+          current_value: v.current_value,
+          target_date: v.target_date,
+          status: v.status,
+        };
+      });
+
+      return formatBodyCompSummary(
+        processedEntries,
+        processedGoals,
+        {
+          from: fromISO.split("T")[0],
+          to: toISO.split("T")[0],
+        },
+      );
     }),
   );
 }


### PR DESCRIPTION
## Changes

- New `bodycomp_summary` MCP tool: retrieves body composition snapshots with delta vs previous entry and goal progress tracking
- 3 helpers in `lib.ts`: `extractBodyCompMetrics`, `computeBodyCompDelta`, `formatBodyCompSummary` with 5 unit tests
- Output includes: latest metrics, directional arrows (↑/↓), goal status vs `measurement_goal` targets, and ⚠ flags for non-standard measurement conditions

## Testing
- 84 Python tests: ✅
- 53 Deno tests: ✅
- `deno check`: ✅
- Schema drift: ✅

Closes #9