### PR TITLE
test: add unit tests for memories and health tool modules

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,4 +15,8 @@ echo "=== Deno tests ==="
 deno test supabase/functions/alexandria/lib.test.ts --allow-read --allow-env
 
 echo ""
+echo "=== Deno tool tests ==="
+deno test supabase/functions/alexandria/tools/memories.test.ts supabase/functions/alexandria/tools/health.test.ts --allow-read --allow-env
+
+echo ""
 echo "=== All tests passed ==="

--- a/supabase/functions/alexandria/tools/health.test.ts
+++ b/supabase/functions/alexandria/tools/health.test.ts
@@ -1,0 +1,161 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1.0.12";
+import {
+  recordToText,
+  extractNumericValue,
+  extractBodyCompMetrics,
+  computeBodyCompDelta,
+  formatBodyCompSummary,
+} from "../lib.ts";
+
+Deno.test("recordToText serializes sleep entry correctly", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    numeric_value: 8,
+    value: { duration_hours: 8, bed_time: "22:00", wake_time: "06:00" }
+  };
+  const text = recordToText("sleep", record);
+  assertEquals(text.includes("slept 8 hours"), true);
+  assertEquals(text.includes("from 22:00"), true);
+  assertEquals(text.includes("to 06:00"), true);
+});
+
+Deno.test("recordToText serializes exercise entry correctly", () => {
+    const record = {
+        timestamp: "2026-06-06T12:00:00Z",
+        numeric_value: 300,
+        duration_s: 1800,
+        value: { name: "Running" }
+    };
+    const text = recordToText("exercise", record);
+    assertEquals(text.includes("exercise on"), true);
+    assertEquals(text.includes("value: 300"), true);
+    assertEquals(text.includes("duration: 30min"), true);
+});
+
+Deno.test("recordToText serializes heart_rate entry correctly", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    numeric_value: 70
+  };
+  const text = recordToText("heart_rate", record);
+  assertEquals(text.includes("Heart rate of 70 bpm"), true);
+});
+
+Deno.test("recordToText serializes weight entry correctly", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    numeric_value: 80
+  };
+  const text = recordToText("weight", record);
+  assertEquals(text.includes("Weight: 80 kg"), true);
+});
+
+Deno.test("recordToText serializes body_composition entry correctly", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    value: { weight_kg: 80, body_fat_percent: 20 }
+  };
+  const text = recordToText("body_composition", record);
+  assertEquals(text.includes("Body composition on"), true);
+  assertEquals(text.includes('"weight_kg":80'), true);
+});
+
+Deno.test("extractNumericValue returns correct value for each type", () => {
+  assertEquals(extractNumericValue("steps", { count: 1000 }), 1000);
+  assertEquals(extractNumericValue("heart_rate", { bpm: 70 }), 70);
+  assertEquals(extractNumericValue("weight", { weight_kg: 80 }), 80);
+  assertEquals(extractNumericValue("sleep", { duration_hours: 8 }), 8);
+  assertEquals(extractNumericValue("exercise", { duration_min: 30 }), 30);
+  assertEquals(extractNumericValue("exercise", { calories: 300 }), 300);
+  assertEquals(extractNumericValue("blood_pressure", { systolic: 120 }), 120);
+  assertEquals(extractNumericValue("body_composition", { weight_kg: 80 }), 80);
+});
+
+Deno.test("extractNumericValue returns null for missing key", () => {
+  assertEquals(extractNumericValue("steps", {}), null);
+  assertEquals(extractNumericValue("unknown", { val: 10 }), null);
+});
+
+Deno.test("extractBodyCompMetrics extracts all 9 fields", () => {
+  const value = {
+    weight_kg: 80,
+    body_fat_percent: 20,
+    skeletal_muscle_kg: 40,
+    body_water_kg: 50,
+    waist_cm: 85,
+    chest_cm: 100,
+    arm_cm: 35,
+    thigh_cm: 55,
+    calf_cm: 38,
+    extra: 10
+  };
+  const metrics = extractBodyCompMetrics(value);
+  assertEquals(metrics.weight_kg, 80);
+  assertEquals(metrics.body_fat_percent, 20);
+  assertEquals(metrics.skeletal_muscle_kg, 40);
+  assertEquals(metrics.body_water_kg, 50);
+  assertEquals(metrics.waist_cm, 85);
+  assertEquals(metrics.chest_cm, 100);
+  assertEquals(metrics.arm_cm, 35);
+  assertEquals(metrics.thigh_cm, 55);
+  assertEquals(metrics.calf_cm, 38);
+});
+
+Deno.test("extractBodyCompMetrics returns null for missing fields", () => {
+    const metrics = extractBodyCompMetrics({});
+    assertEquals(metrics.weight_kg, null);
+    assertEquals(metrics.body_fat_percent, null);
+});
+
+Deno.test("computeBodyCompDelta computes up/down/flat correctly", () => {
+  const current = { weight_kg: 80, body_fat_percent: 19, skeletal_muscle_kg: 40 };
+  const previous = { weight_kg: 81, body_fat_percent: 20, skeletal_muscle_kg: 40 };
+  const deltas = computeBodyCompDelta(current, previous);
+  
+  assertEquals(deltas.weight_kg, { delta: -1, direction: "down" });
+  assertEquals(deltas.body_fat_percent, { delta: -1, direction: "down" });
+  assertEquals(deltas.skeletal_muscle_kg, { delta: 0, direction: "flat" });
+});
+
+Deno.test("computeBodyCompDelta returns null for missing either side", () => {
+    const current = { weight_kg: 80 };
+    const previous = { body_fat_percent: 20 };
+    const deltas = computeBodyCompDelta(current, previous);
+    assertEquals(deltas.weight_kg, null);
+    assertEquals(deltas.body_fat_percent, null);
+});
+
+Deno.test("formatBodyCompSummary returns 'No entries' message for empty array", () => {
+  const summary = formatBodyCompSummary([], [], { from: "2026-06-01", to: "2026-06-07" });
+  assertEquals(summary, "No body composition entries found in the selected period.");
+});
+
+Deno.test("formatBodyCompSummary includes latest metrics in output", () => {
+  const entries = [{
+    timestamp: "2026-06-06T12:00:00Z",
+    metrics: { weight_kg: 80, body_fat_percent: 20 }
+  }];
+  const summary = formatBodyCompSummary(entries as any, [], { from: "2026-06-01", to: "2026-06-07" });
+  assertEquals(summary.includes("Weight: 80kg"), true);
+  assertEquals(summary.includes("Body Fat: 20%"), true);
+});
+
+Deno.test("formatBodyCompSummary includes delta arrows", () => {
+    const entries = [{
+      timestamp: "2026-06-06T12:00:00Z",
+      metrics: { weight_kg: 80 },
+      delta: { weight_kg: { delta: -1, direction: "down" } }
+    }];
+    const summary = formatBodyCompSummary(entries as any, [], { from: "2026-06-01", to: "2026-06-07" });
+    assertEquals(summary.includes("Weight: 80kg (↓ 1kg)"), true);
+});
+
+Deno.test("formatBodyCompSummary includes quality warning for non-standard context", () => {
+    const entries = [{
+      timestamp: "2026-06-06T12:00:00Z",
+      metrics: { weight_kg: 80 },
+      context: "evening"
+    }];
+    const summary = formatBodyCompSummary(entries as any, [], { from: "2026-06-01", to: "2026-06-07" });
+    assertEquals(summary.includes("⚠ Non-standard conditions: evening"), true);
+});

--- a/supabase/functions/alexandria/tools/memories.test.ts
+++ b/supabase/functions/alexandria/tools/memories.test.ts
@@ -1,0 +1,79 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1.0.12";
+import {
+  simpleClassify,
+  sanitizeClassification,
+  VALID_CATEGORIES,
+  recordToText,
+  normalizeStringArray,
+} from "../lib.ts";
+
+Deno.test("simpleClassify returns valid category for short text", () => {
+  const result = simpleClassify("I had a great idea for a new app");
+  assertEquals(result.category, "idea");
+});
+
+Deno.test("simpleClassify extracts title from content", () => {
+  const result = simpleClassify("Something");
+  assertExists(result);
+  assertEquals(result.title, null);
+});
+
+Deno.test("sanitizeClassification clamps importance to 1-10", () => {
+  assertEquals(sanitizeClassification({ importance: 11 }).importance, 5);
+  assertEquals(sanitizeClassification({ importance: 0 }).importance, 5);
+  assertEquals(sanitizeClassification({ importance: 7 }).importance, 7);
+});
+
+Deno.test("sanitizeClassification fixes invalid category to 'note'", () => {
+  assertEquals(sanitizeClassification({ category: "invalid" }).category, "note");
+});
+
+Deno.test("sanitizeClassification cleans tags array", () => {
+  const result = sanitizeClassification({ tags: [" TAG1 ", "tag2", "tag1"] });
+  assertEquals(result.tags, ["tag1", "tag2"]);
+});
+
+Deno.test("normalizeStringArray trims whitespace", () => {
+  assertEquals(normalizeStringArray(["  a  ", "b"]), ["a", "b"]);
+});
+
+Deno.test("normalizeStringArray deduplicates", () => {
+  assertEquals(normalizeStringArray(["a", "a", "b"]), ["a", "b"]);
+});
+
+Deno.test("normalizeStringArray lowercases when requested", () => {
+  assertEquals(normalizeStringArray(["A", "B"], { lowercase: true }), ["a", "b"]);
+});
+
+Deno.test("normalizeStringArray handles empty arrays", () => {
+  assertEquals(normalizeStringArray([]), []);
+  assertEquals(normalizeStringArray(null), []);
+});
+
+Deno.test("recordToText serializes memory with all fields", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    numeric_value: 100,
+    duration_s: 600,
+  };
+  const text = recordToText("steps", record);
+  assertExists(text);
+  assertEquals(text.includes("100 steps"), true);
+  assertEquals(text.includes("10 minutes"), true);
+});
+
+Deno.test("recordToText handles missing optional fields", () => {
+  const record = {
+    timestamp: "2026-06-06T12:00:00Z",
+    numeric_value: 100,
+  };
+  const text = recordToText("steps", record);
+  assertEquals(text.includes("100 steps"), true);
+  assertEquals(text.includes("minutes"), false);
+});
+
+Deno.test("VALID_CATEGORIES contains expected categories", () => {
+  assertEquals(VALID_CATEGORIES.includes("note"), true);
+  assertEquals(VALID_CATEGORIES.includes("idea"), true);
+  assertEquals(VALID_CATEGORIES.includes("task"), true);
+});


### PR DESCRIPTION
## Changes

- `tools/memories.test.ts`: 12 tests covering `simpleClassify`, `sanitizeClassification`, `normalizeStringArray`, `recordToText`
- `tools/health.test.ts`: 15 tests covering `recordToText` (5 health types), `extractNumericValue`, `extractBodyCompMetrics`, `computeBodyCompDelta`, `formatBodyCompSummary`
- Updated `run-tests.sh` to include new tool test files

## Testing
- 58 lib tests: ✅
- 27 new tool tests: ✅
- Total Deno: 85 tests passing

Closes #8