### PR TITLE
feat: add build_room_manifest tool

### DIFF
--- a/supabase/functions/alexandria/tools/briefs.ts
+++ b/supabase/functions/alexandria/tools/briefs.ts
@@ -209,4 +209,467 @@ export function registerBriefsTools(
       return `Found ${data.length} brief(s):\n\n${results.join("\n\n")}`;
     }),
   );
+
+  server.registerTool(
+    "build_room_manifest",
+    {
+      title: "Build Room Manifest",
+      description:
+        "Generates a structured manifest for a draft room based on topic queries and filters, and optionally persists it.",
+      inputSchema: {
+        topic: z.string().describe("Topic or query to prepare the room for"),
+        kind: z.string().optional().describe("Filter by brief kind"),
+        project_ref: z.string().optional().describe("Filter by project reference"),
+        entity_ref: z.string().optional().describe("Filter by entity reference"),
+        from: z.string().optional().describe("Start date YYYY-MM-DD"),
+        to: z.string().optional().describe("End date YYYY-MM-DD"),
+        max_items: z.number().optional().default(15).describe("Max briefs to consider"),
+        persist: z.boolean().optional().default(false).describe("Save manifest as a draft_room brief"),
+      },
+    },
+    wrapHandler(
+      async ({
+        topic,
+        kind,
+        project_ref,
+        entity_ref,
+        from,
+        to,
+        max_items,
+        persist,
+      }) => {
+        const qEmb = await getEmbedding(topic);
+        const { data: briefs, error } = await supabase.rpc("search_briefs", {
+          query_embedding: qEmb,
+          match_threshold: 0.4,
+          match_count: max_items,
+          filter_kind: kind ? kind.trim().toLowerCase() : null,
+          filter_source_job: null,
+          filter_date_from: from || null,
+          filter_date_to: to || null,
+          filter_topics: null,
+          filter_project_refs: project_ref ? [project_ref.trim()] : null,
+          filter_entity_refs: entity_ref ? [entity_ref.trim()] : null,
+        });
+
+        if (error) {
+          throw new Error(`Brief search failed: ${error.message}`);
+        }
+
+        const today = new Date();
+        const fresh_inputs: BriefMatch[] = [];
+        const stale_inputs: BriefMatch[] = [];
+
+        for (const b of (briefs as BriefMatch[]) || []) {
+          if (isBriefFresh(b.brief_date, today)) {
+            fresh_inputs.push(b);
+          } else {
+            stale_inputs.push(b);
+          }
+        }
+
+        const conflicting_briefs = detectConflicts((briefs as BriefMatch[]) || []);
+        const proof_gaps = detectProofGaps((briefs as BriefMatch[]) || [], fresh_inputs.length, stale_inputs.length);
+        const readOrderBriefs = computeReadOrder(fresh_inputs, stale_inputs);
+        const suggested_read_order = readOrderBriefs.map((b, index) => {
+          return `${index + 1}. ${b.title} (${b.brief_date}, ${b.kind})`;
+        });
+
+        const next_actions = computeNextActions(
+          ((briefs as BriefMatch[]) || []).length,
+          fresh_inputs.length,
+          conflicting_briefs.length > 0,
+        );
+
+        const manifest: RoomManifest = {
+          topic,
+          total_found: ((briefs as BriefMatch[]) || []).length,
+          fresh_inputs,
+          stale_inputs,
+          conflicting_briefs,
+          proof_gaps,
+          suggested_read_order,
+          next_actions,
+        };
+
+        const manifestText = formatRoomManifest(manifest);
+
+        let persistMsg = "";
+        if (persist) {
+          const todayStr = today.toISOString().split("T")[0];
+          const normalizedBody = normalizeBriefBody(manifestText);
+          const contentHash = await computeBriefContentHash({
+            source_job: "room-builder",
+            title: `Draft Room: ${topic}`,
+            brief_date: todayStr,
+            kind: "draft_room",
+            body_markdown: normalizedBody,
+          });
+
+          // Check if brief exists
+          const { data: existing, error: existingError } = await supabase
+            .from("briefs")
+            .select("id")
+            .eq("content_hash", contentHash)
+            .maybeSingle();
+
+          if (existingError) {
+            throw new Error(`Brief lookup failed: ${existingError.message}`);
+          }
+
+          if (existing) {
+            persistMsg = `\n\n[Duplicate brief blocked: manifest already persisted as brief ID ${existing.id}]`;
+          } else {
+            const row: Record<string, unknown> = {
+              source_job: "room-builder",
+              title: `Draft Room: ${topic}`,
+              brief_date: todayStr,
+              kind: "draft_room",
+              body_markdown: normalizedBody,
+              topics: [],
+              project_refs: project_ref ? [project_ref.trim()] : [],
+              entity_refs: entity_ref ? [entity_ref.trim()] : [],
+              content_hash: contentHash,
+              metadata: {},
+            };
+
+            const embedding = await getEmbedding(briefToText(row));
+            row.embedding = embedding;
+
+            const { data: inserted, error: insertError } = await supabase
+              .from("briefs")
+              .insert(row)
+              .select("id")
+              .single();
+
+            if (insertError || !inserted) {
+              throw new Error(`Failed to persist draft room brief: ${insertError?.message || "unknown error"}`);
+            }
+            persistMsg = `\n\n[Persisted draft room brief as ID ${inserted.id}]`;
+          }
+        }
+
+        return manifestText + persistMsg;
+      },
+    ),
+  );
 }
+
+// Interfaces for Room Manifest Tool
+export interface BriefMatch {
+  id: string;
+  title: string;
+  brief_date: string;
+  kind: string;
+  source_job: string;
+  body_markdown: string;
+  topics?: string[] | null;
+  project_refs?: string[] | null;
+  entity_refs?: string[] | null;
+  similarity: number;
+}
+
+export interface ConflictPair {
+  brief_a_id: string;
+  brief_b_id: string;
+  brief_a_title: string;
+  brief_b_title: string;
+  reason: string;
+}
+
+export interface ProofGap {
+  gap_type: "thin_evidence" | "outdated" | "no_research_backing";
+  description: string;
+}
+
+export interface RoomManifest {
+  topic: string;
+  total_found: number;
+  fresh_inputs: BriefMatch[];
+  stale_inputs: BriefMatch[];
+  conflicting_briefs: ConflictPair[];
+  proof_gaps: ProofGap[];
+  suggested_read_order: string[];
+  next_actions: string[];
+}
+
+// Helper functions for Room Manifest
+export function isBriefFresh(briefDateStr: string, referenceDate: Date = new Date()): boolean {
+  try {
+    const [y, m, d] = briefDateStr.split("-").map(Number);
+    const briefUtc = Date.UTC(y, m - 1, d);
+    const refUtc = Date.UTC(
+      referenceDate.getUTCFullYear(),
+      referenceDate.getUTCMonth(),
+      referenceDate.getUTCDate(),
+    );
+    const diffDays = (refUtc - briefUtc) / (1000 * 60 * 60 * 24);
+    return diffDays >= 0 && diffDays <= 14;
+  } catch {
+    return false;
+  }
+}
+
+const OPPOSING_PAIRS = [
+  ["confirmed", "rumored"],
+  ["launched", "pending"],
+  ["approved", "denied"],
+  ["bullish", "bearish"],
+];
+
+const IGNORED_KEYWORDS = new Set([
+  "the", "and", "for", "with", "that", "this", "from", "are", "was", "were", "been", "have", "has", "had",
+  "is", "will", "would", "shall", "should", "can", "could", "may", "might", "must",
+  "about", "above", "across", "after", "against", "along", "among", "around", "at", "before", "behind", "below", "beneath", "beside",
+  "between", "beyond", "but", "by", "concerning", "considering", "despite", "down", "during", "except", "following",
+  "in", "inside", "into", "like", "minus", "near", "next", "of", "off", "on", "onto", "opposite", "out", "outside", "over", "past",
+  "plus", "regarding", "round", "save", "since", "than", "through", "to", "toward", "towards", "under", "underneath", "unlike",
+  "until", "up", "upon", "versus", "via", "without",
+  "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+  "january", "february", "march", "april", "june", "july", "august", "september", "october", "november", "december",
+  "mon", "tue", "wed", "thu", "fri", "sat", "sun",
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+  "year", "years", "month", "months", "week", "weeks", "day", "days", "hour", "hours", "minute", "minutes", "second", "seconds"
+]);
+
+export function extractNumbers(text: string): { keyword: string; value: number }[] {
+  const results: { keyword: string; value: number }[] = [];
+  const regex = /\b([a-zA-Z]{3,20})\s*[:=]?\s*\$?(\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)\b/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const keyword = match[1].toLowerCase();
+    if (IGNORED_KEYWORDS.has(keyword)) {
+      continue;
+    }
+    const numStr = match[2].replace(/,/g, "");
+    const value = parseFloat(numStr);
+    if (!isNaN(value)) {
+      results.push({ keyword, value });
+    }
+  }
+  return results;
+}
+
+export function hasOpposingWords(text1: string, text2: string): string | null {
+  for (const [w1, w2] of OPPOSING_PAIRS) {
+    const r1 = new RegExp(`\\b${w1}\\b`, "i");
+    const r2 = new RegExp(`\\b${w2}\\b`, "i");
+    if ((r1.test(text1) && r2.test(text2)) || (r2.test(text1) && r1.test(text2))) {
+      return `Opposing status words: '${w1}' vs '${w2}'`;
+    }
+  }
+  return null;
+}
+
+export function detectConflicts(briefs: BriefMatch[]): ConflictPair[] {
+  const conflicts: ConflictPair[] = [];
+  for (let i = 0; i < briefs.length; i++) {
+    for (let j = i + 1; j < briefs.length; j++) {
+      const b1 = briefs[i];
+      const b2 = briefs[j];
+
+      // Check opposing words
+      const opposing = hasOpposingWords(b1.body_markdown, b2.body_markdown);
+      if (opposing) {
+        conflicts.push({
+          brief_a_id: b1.id,
+          brief_b_id: b2.id,
+          brief_a_title: b1.title,
+          brief_b_title: b2.title,
+          reason: opposing,
+        });
+        continue;
+      }
+
+      // Check number variance
+      const nums1 = extractNumbers(b1.body_markdown);
+      const nums2 = extractNumbers(b2.body_markdown);
+
+      for (const n1 of nums1) {
+        const matching = nums2.find((n2) => n2.keyword === n1.keyword);
+        if (matching) {
+          const v1 = n1.value;
+          const v2 = matching.value;
+          const min = Math.min(v1, v2);
+          const max = Math.max(v1, v2);
+          if (min > 0 && (max - min) / min > 0.2) {
+            conflicts.push({
+              brief_a_id: b1.id,
+              brief_b_id: b2.id,
+              brief_a_title: b1.title,
+              brief_b_title: b2.title,
+              reason: `Number variance for '${n1.keyword}': ${v1} vs ${v2} (>20% variance)`,
+            });
+            break; // only one conflict per pair
+          }
+        }
+      }
+    }
+  }
+  return conflicts;
+}
+
+export function detectProofGaps(
+  briefs: BriefMatch[],
+  freshCount: number,
+  staleCount: number,
+): ProofGap[] {
+  const gaps: ProofGap[] = [];
+  const total = briefs.length;
+  if (total === 1) {
+    gaps.push({
+      gap_type: "thin_evidence",
+      description: "Thin evidence: only 1 source found for the topic",
+    });
+  }
+  if (total > 0 && freshCount === 0) {
+    gaps.push({
+      gap_type: "outdated",
+      description: "May be outdated: all inputs are stale (>14 days old)",
+    });
+  }
+  const hasResearchOrCoach = briefs.some(
+    (b) => b.kind === "night_research" || b.kind === "content_coach",
+  );
+  if (total > 0 && !hasResearchOrCoach) {
+    gaps.push({
+      gap_type: "no_research_backing",
+      description: "No research backing: no night_research or content_coach briefs found",
+    });
+  }
+  return gaps;
+}
+
+export function computeReadOrder(
+  fresh: BriefMatch[],
+  stale: BriefMatch[],
+): BriefMatch[] {
+  // Sort fresh by date descending, then similarity descending
+  const sortedFresh = [...fresh].sort((a, b) => {
+    const dateCompare = b.brief_date.localeCompare(a.brief_date);
+    if (dateCompare !== 0) return dateCompare;
+    return b.similarity - a.similarity;
+  });
+
+  // Sort stale by similarity descending, then date descending
+  const sortedStale = [...stale].sort((a, b) => {
+    const simCompare = b.similarity - a.similarity;
+    if (simCompare !== 0) return simCompare;
+    return b.brief_date.localeCompare(a.brief_date);
+  });
+
+  const order: BriefMatch[] = [];
+  const processedIds = new Set<string>();
+
+  // 1. Most recent fresh brief first
+  if (sortedFresh.length > 0) {
+    const firstFresh = sortedFresh[0];
+    order.push(firstFresh);
+    processedIds.add(firstFresh.id);
+  }
+
+  // 2. Then highest-similarity stale brief
+  if (sortedStale.length > 0) {
+    const firstStale = sortedStale[0];
+    order.push(firstStale);
+    processedIds.add(firstStale.id);
+  }
+
+  // 3. Then remaining by similarity descending
+  const remaining = [
+    ...sortedFresh.filter((b) => !processedIds.has(b.id)),
+    ...sortedStale.filter((b) => !processedIds.has(b.id)),
+  ];
+
+  // Sort remaining by similarity descending
+  remaining.sort((a, b) => b.similarity - a.similarity);
+
+  order.push(...remaining);
+  return order;
+}
+
+export function computeNextActions(
+  total: number,
+  freshCount: number,
+  hasConflicts: boolean,
+): string[] {
+  const actions: string[] = [];
+  if (hasConflicts) {
+    actions.push("Review conflicting briefs before drafting");
+  }
+  if (total > 0 && freshCount === 0) {
+    actions.push("Refresh research — all inputs are >14 days old");
+  }
+  if (total <= 1) {
+    actions.push("Gather additional sources before drafting");
+  }
+  if (actions.length === 0) {
+    actions.push("Room is ready — proceed to draft");
+  }
+  return actions;
+}
+
+export function formatRoomManifest(manifest: RoomManifest): string {
+  const parts: string[] = [];
+  parts.push(`Room Manifest for Topic: "${manifest.topic}"`);
+  parts.push(`Total Briefs Found: ${manifest.total_found}`);
+  parts.push("");
+
+  parts.push(`Fresh Inputs (${manifest.fresh_inputs.length}):`);
+  if (manifest.fresh_inputs.length === 0) {
+    parts.push("- None");
+  } else {
+    for (const b of manifest.fresh_inputs) {
+      parts.push(`- ${b.title} (${b.brief_date}, ${b.kind}) [${(b.similarity * 100).toFixed(1)}% match]`);
+    }
+  }
+  parts.push("");
+
+  parts.push(`Stale Inputs (${manifest.stale_inputs.length}):`);
+  if (manifest.stale_inputs.length === 0) {
+    parts.push("- None");
+  } else {
+    for (const b of manifest.stale_inputs) {
+      parts.push(`- ${b.title} (${b.brief_date}, ${b.kind}) [${(b.similarity * 100).toFixed(1)}% match]`);
+    }
+  }
+  parts.push("");
+
+  parts.push(`Potential Conflicts (${manifest.conflicting_briefs.length}):`);
+  if (manifest.conflicting_briefs.length === 0) {
+    parts.push("- None");
+  } else {
+    for (const c of manifest.conflicting_briefs) {
+      parts.push(`- "${c.brief_a_title}" vs "${c.brief_b_title}": ${c.reason}`);
+    }
+  }
+  parts.push("");
+
+  parts.push(`Proof Gaps (${manifest.proof_gaps.length}):`);
+  if (manifest.proof_gaps.length === 0) {
+    parts.push("- None");
+  } else {
+    for (const g of manifest.proof_gaps) {
+      parts.push(`- ${g.description}`);
+    }
+  }
+  parts.push("");
+
+  parts.push("Suggested Read Order:");
+  if (manifest.suggested_read_order.length === 0) {
+    parts.push("- None");
+  } else {
+    for (const item of manifest.suggested_read_order) {
+      parts.push(item);
+    }
+  }
+  parts.push("");
+
+  parts.push("Next Actions:");
+  for (const action of manifest.next_actions) {
+    parts.push(`- ${action}`);
+  }
+
+  return parts.join("\n");
+}
+

--- a/supabase/functions/alexandria/tools/room_manifest.test.ts
+++ b/supabase/functions/alexandria/tools/room_manifest.test.ts
@@ -1,0 +1,303 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1.0.12";
+import { supabase } from "../config.ts";
+import { registerBriefsTools } from "./briefs.ts";
+import {
+  isBriefFresh,
+  extractNumbers,
+  hasOpposingWords,
+  detectConflicts,
+  detectProofGaps,
+  computeReadOrder,
+  computeNextActions,
+  formatRoomManifest,
+} from "./briefs.ts";
+
+Deno.test("Freshness bucketing - within 14 days is fresh, older is stale", () => {
+  const refDate = new Date("2026-06-15T00:00:00Z");
+  // 14 days ago is 2026-06-01
+  assertEquals(isBriefFresh("2026-06-15", refDate), true);
+  assertEquals(isBriefFresh("2026-06-02", refDate), true);
+  assertEquals(isBriefFresh("2026-06-01", refDate), true);
+  assertEquals(isBriefFresh("2026-05-31", refDate), false);
+  assertEquals(isBriefFresh("2026-05-15", refDate), false);
+});
+
+Deno.test("Conflict detection by opposing status words", () => {
+  const brief1 = {
+    id: "1",
+    title: "Brief 1",
+    brief_date: "2026-06-15",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "The project status is confirmed.",
+    similarity: 0.9,
+  };
+  const brief2 = {
+    id: "2",
+    title: "Brief 2",
+    brief_date: "2026-06-14",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "The project status is rumored.",
+    similarity: 0.8,
+  };
+  const conflicts = detectConflicts([brief1, brief2]);
+  assertEquals(conflicts.length, 1);
+  assertEquals(conflicts[0].reason.includes("confirmed"), true);
+  assertEquals(conflicts[0].reason.includes("rumored"), true);
+});
+
+Deno.test("Conflict detection by number variance (>20% difference)", () => {
+  const brief1 = {
+    id: "1",
+    title: "Brief 1",
+    brief_date: "2026-06-15",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "Revenue: $100,000",
+    similarity: 0.9,
+  };
+  const brief2 = {
+    id: "2",
+    title: "Brief 2",
+    brief_date: "2026-06-14",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "Revenue: 130,000",
+    similarity: 0.8,
+  };
+  const conflicts = detectConflicts([brief1, brief2]);
+  assertEquals(conflicts.length, 1);
+  assertEquals(conflicts[0].reason.includes("revenue"), true);
+  assertEquals(conflicts[0].reason.includes("100000 vs 130000"), true);
+});
+
+Deno.test("Proof gap - single-source detection", () => {
+  const brief = {
+    id: "1",
+    title: "Brief 1",
+    brief_date: "2026-06-15",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "Some content",
+    similarity: 0.9,
+  };
+  const gaps = detectProofGaps([brief], 1, 0);
+  const thinEvidenceGap = gaps.find((g) => g.gap_type === "thin_evidence");
+  assertEquals(!!thinEvidenceGap, true);
+});
+
+Deno.test("Proof gap - stale-only detection", () => {
+  const brief1 = {
+    id: "1",
+    title: "Brief 1",
+    brief_date: "2026-05-15",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "Some content",
+    similarity: 0.9,
+  };
+  const brief2 = {
+    id: "2",
+    title: "Brief 2",
+    brief_date: "2026-05-14",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "Some content",
+    similarity: 0.8,
+  };
+  const gaps = detectProofGaps([brief1, brief2], 0, 2);
+  const outdatedGap = gaps.find((g) => g.gap_type === "outdated");
+  assertEquals(!!outdatedGap, true);
+});
+
+Deno.test("Suggested read order - fresh first, then highest-similarity stale, then remaining by similarity descending", () => {
+  const f1 = {
+    id: "f1",
+    title: "Fresh 1",
+    brief_date: "2026-06-10",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "A",
+    similarity: 0.7,
+  };
+  const f2 = {
+    id: "f2",
+    title: "Fresh 2",
+    brief_date: "2026-06-12",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "B",
+    similarity: 0.8,
+  };
+  const s1 = {
+    id: "s1",
+    title: "Stale 1",
+    brief_date: "2026-05-01",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "C",
+    similarity: 0.9,
+  };
+  const s2 = {
+    id: "s2",
+    title: "Stale 2",
+    brief_date: "2026-04-15",
+    kind: "report",
+    source_job: "job",
+    body_markdown: "D",
+    similarity: 0.6,
+  };
+
+  const order = computeReadOrder([f1, f2], [s1, s2]);
+  assertEquals(order[0].id, "f2");
+  assertEquals(order[1].id, "s1");
+  assertEquals(order[2].id, "f1");
+  assertEquals(order[3].id, "s2");
+});
+
+Deno.test("Next actions generation based on manifest state", () => {
+  // Scenario 1: Clean
+  const actionsClean = computeNextActions(3, 2, false);
+  assertEquals(actionsClean, ["Room is ready — proceed to draft"]);
+
+  // Scenario 2: Conflicts
+  const actionsConflict = computeNextActions(3, 2, true);
+  assertEquals(actionsConflict.includes("Review conflicting briefs before drafting"), true);
+
+  // Scenario 3: Stale only
+  const actionsStale = computeNextActions(2, 0, false);
+  assertEquals(actionsStale.includes("Refresh research — all inputs are >14 days old"), true);
+
+  // Scenario 4: Thin evidence
+  const actionsThin = computeNextActions(1, 1, false);
+  assertEquals(actionsThin.includes("Gather additional sources before drafting"), true);
+});
+
+Deno.test("Full build_room_manifest integration with mocked database", async () => {
+  // Save original supabase methods
+  const originalRpc = supabase.rpc;
+  const originalFrom = supabase.from;
+  const originalFetch = globalThis.fetch;
+
+  // Setup mocks
+  let rpcCalled = false;
+  let selectCalled = false;
+  let insertCalled = false;
+
+  // Mock global fetch to intercept OpenRouter embeddings API calls
+  globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/embeddings")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ embedding: [0.1, 0.2, 0.3] }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+    }
+    return originalFetch(input, init);
+  };
+
+  supabase.rpc = function (fnName: string, params: any) {
+    rpcCalled = true;
+    assertEquals(fnName, "search_briefs");
+    assertExists(params.query_embedding);
+    return Promise.resolve({
+      data: [
+        {
+          id: "b1",
+          title: "Fresh Brief",
+          brief_date: new Date().toISOString().split("T")[0],
+          kind: "night_research",
+          source_job: "crawler",
+          body_markdown: "Revenue: 100",
+          similarity: 0.95,
+        },
+        {
+          id: "b2",
+          title: "Stale Brief",
+          brief_date: "2026-05-01",
+          kind: "report",
+          source_job: "manual",
+          body_markdown: "Revenue: 150",
+          similarity: 0.85,
+        }
+      ],
+      error: null,
+    }) as any;
+  };
+
+  supabase.from = function (table: string) {
+    assertEquals(table, "briefs");
+    return {
+      select: function () {
+        selectCalled = true;
+        return {
+          eq: function () {
+            return {
+              maybeSingle: function () {
+                // Return no existing to trigger insertion
+                return Promise.resolve({ data: null, error: null });
+              }
+            };
+          }
+        };
+      },
+      insert: function (row: any) {
+        insertCalled = true;
+        assertEquals(row.kind, "draft_room");
+        assertEquals(row.source_job, "room-builder");
+        return {
+          select: function () {
+            return {
+              single: function () {
+                return Promise.resolve({ data: { id: "new_manifest_brief" }, error: null });
+              }
+            };
+          }
+        };
+      }
+    } as any;
+  };
+
+  try {
+    // Capture registered tool handler
+    let capturedHandler: any = null;
+    const mockServer = {
+      registerTool: (name: string, _config: any, handler: any) => {
+        if (name === "build_room_manifest") {
+          capturedHandler = handler;
+        }
+      }
+    } as any;
+
+    registerBriefsTools(mockServer, () => undefined);
+    assertExists(capturedHandler);
+
+    const resultOk = await capturedHandler({
+      topic: "Revenue status",
+      persist: true,
+    });
+
+    assertEquals(resultOk.isError, undefined);
+    assertExists(resultOk.content);
+    const text = resultOk.content[0].text;
+    
+    // Verify integration results
+    assertEquals(rpcCalled, true);
+    assertEquals(selectCalled, true);
+    assertEquals(insertCalled, true);
+    assertEquals(text.includes("Room Manifest for Topic"), true);
+    assertEquals(text.includes("Potential Conflicts (1)"), true);
+    assertEquals(text.includes("Number variance for 'revenue': 100 vs 150"), true);
+    assertEquals(text.includes("Persisted draft room brief as ID new_manifest_brief"), true);
+  } finally {
+    // Cleanup mocks
+    supabase.rpc = originalRpc;
+    supabase.from = originalFrom;
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Add `build_room_manifest` tool to the briefs MCP toolset
- Assembles a decision-ready manifest from existing briefs: fresh vs stale bucketing, conflict detection (opposing status words + numeric variance), proof gap analysis (thin evidence, stale-only, missing research backing)
- Computes suggested read order (fresh first → highest-similarity stale → remaining by similarity)
- Generates actionable next actions based on manifest state
- Optional `persist` flag saves manifest as a `draft_room` brief with content_hash dedupe

## Verification
- `deno test --allow-all --config deno.json room_manifest.test.ts` — 8 tests passed (7 unit + 1 integration with mocked DB)
- Independent code review: passed, no security concerns, no logic errors, no regressions to existing 3 brief tools (purely additive: 463 insertions, 0 deletions to existing code)

Closes #16
